### PR TITLE
ESWE-1794: Pin actions to full SHA

### DIFF
--- a/.github/workflows/cd-main.yaml
+++ b/.github/workflows/cd-main.yaml
@@ -19,12 +19,12 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.ECR_ROLE_TO_ASSUME }}
           aws-region: ${{ vars.ECR_REGION }}
-      - uses: aws-actions/amazon-ecr-login@v2
+      - uses: aws-actions/amazon-ecr-login@183a1442edf41672e66566b7fc560e297a290896 # v2
         id: login-ecr
       - run: |
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG .


### PR DESCRIPTION
Pin these versions to full SHA
```
  Pinned action: actions/checkout@v4 -> 34e1148
  Pinned action: aws-actions/configure-aws-credentials@v4 -> 7474bc4
  Pinned action: aws-actions/amazon-ecr-login@v2 -> 183a144
```